### PR TITLE
New CDN-service implementation 

### DIFF
--- a/src/app/components/node/node-images/node-images.component.ts
+++ b/src/app/components/node/node-images/node-images.component.ts
@@ -39,7 +39,15 @@ export class NodeImagesComponent implements OnInit, OnChanges {
       return;
     }
 
-    this.processedImageUrls = this.cdn.processUrls(this.imageUrls);
+    
+  this.cdn.processUrls(this.imageUrls).subscribe(
+    processedUrls => {
+      this.processedImageUrls = processedUrls;
+    },
+    error => {
+      console.error('Error processing image URLs:', error);
+    }
+  );
   }
 
   protected readonly Config = Config;

--- a/src/app/components/node/node-link/node-link.component.ts
+++ b/src/app/components/node/node-link/node-link.component.ts
@@ -95,7 +95,18 @@ export class NodeLinkComponent implements OnInit, OnChanges {
       return;
     }
 
-    this.processedUrl = this.cdn.processUrl(this.url);
+    this.cdn.processUrl(this.url).subscribe(
+    processedUrl => {
+      this.processedUrl = processedUrl;
+      const isValidAbsoluteUrl = isValidUrl(this.processedUrl);
+      this.isClickableUrl = isValidAbsoluteUrl && !this.disabled;
+    },
+    error => {
+      console.error('Error processing URL:', error);
+      this.processedUrl = this.url; // Fallback to original URL
+      this.isClickableUrl = false;
+    }
+  );
   }
 
   get cachedLabel(): string | undefined {

--- a/src/app/services/cdn.service.ts
+++ b/src/app/services/cdn.service.ts
@@ -30,7 +30,20 @@ export class CdnService {
     if (!url.includes('opslag.razu.nl')) {
       return of(url);
     }
-
+    // temporary dev-mode section to bypass a dedicated JWT-token server. DO NOT USE IN PRODUCTION.
+    // Token will be invalidated after the PoC is finished.
+    const devmode = false;
+    if (url.includes('opslag.razu.nl') && devmode) {
+      console.log("JWT-token generation bypassed.")
+      url = this._addParamToUrl(
+        url,
+        'token',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MDY0NjQsIm5iZiI6MTcxMTcwNjQ2NCwiZXhwIjoxNzQzMjQyNDY0fQ.ViNS0wWml0EwkF0z75G4cNZxKupYQMLiVB_PQ5kNQm8',
+      );
+      return of(url);
+    }
+    // end of bypass
+    
     const domain = this.extractDomain(url);
     const filename = this.extractFilename(url);
 

--- a/src/app/services/cdn.service.ts
+++ b/src/app/services/cdn.service.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of, forkJoin } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CdnService {
-  constructor() {}
+  private serverIp: string = '192.168.1.1'; // Replace with actual server IP
 
-  private _addParamToUrl(
-    url: string,
-    paramName: string,
-    paramValue: string,
-  ): string {
+  constructor(private http: HttpClient) {}
+
+  private _addParamToUrl(url: string, paramName: string, paramValue: string): string {
     try {
       const urlObj = new URL(url);
       urlObj.searchParams.set(paramName, paramValue);
@@ -21,18 +22,49 @@ export class CdnService {
     }
   }
 
-  processUrls(urls: string[]): string[] {
-    return urls.map((url) => this.processUrl(url));
+  processUrls(urls: string[]): Observable<string[]> {
+    return forkJoin(urls.map(url => this.processUrl(url)));
   }
 
-  processUrl(url: string): string {
-    if (url.includes('opslag.razu.nl')) {
-      url = this._addParamToUrl(
-        url,
-        'token',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTE3MDY0NjQsIm5iZiI6MTcxMTcwNjQ2NCwiZXhwIjoxNzQzMjQyNDY0fQ.ViNS0wWml0EwkF0z75G4cNZxKupYQMLiVB_PQ5kNQm8',
-      );
+  public processUrl(url: string): Observable<string> {
+    if (!url.includes('opslag.razu.nl')) {
+      return of(url);
     }
-    return url;
+
+    const domain = this.extractDomain(url);
+    const filename = this.extractFilename(url);
+
+    return this.generateToken(domain, filename).pipe(
+      map(token => this._addParamToUrl(url, 'token', token)),
+      catchError(error => {
+        console.error('Token generation failed:', error);
+        return of(url);
+      })
+    );
+  }
+
+  private extractDomain(url: string): string {
+    const domainMatch = url.match(/https?:\/\/([^\.]+)\.opslag\.razu\.nl/);
+    return domainMatch ? domainMatch[1] : '';
+  }
+
+private extractFilename(url: string): string {
+  // Extract the part after the last '/'
+  const lastSegment = url.substring(url.lastIndexOf('/') + 1);
+  // Remove any query parameters if present
+  return lastSegment.split('?')[0];
+}
+
+  private generateToken(domain: string, filename: string): Observable<string> {
+    const headers = new HttpHeaders({
+      'ip': this.serverIp,
+      'domain': domain,
+      'file': filename,
+    });
+
+    return this.http.post<{ token: string }>('http://localhost:3000/generate-token', {}, { headers })
+      .pipe(
+        map(response => response.token)
+      );
   }
 }


### PR DESCRIPTION
Includes a switch on line 35 of the cdn-service to switch back to the old hard-coded token. Please note that this token will be invalidated by RAZU once the PoC has finished. 